### PR TITLE
Replace each '&rest body' with '&body body' for proper indentation.

### DIFF
--- a/html/html.lisp
+++ b/html/html.lisp
@@ -161,7 +161,7 @@ NOTE: this will not change the document content encoding, just the META flag ass
 ;;; with-parse-html
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defmacro with-parse-html ((var src &rest keys &key &allow-other-keys) &rest body)
+(defmacro with-parse-html ((var src &rest keys &key &allow-other-keys) &body body)
   `(let ((,var (parse-html ,src ,@keys)))
      (unwind-protect
           (progn ,@body)
@@ -182,7 +182,7 @@ NOTE: this will not change the document content encoding, just the META flag ass
             (append-child fragment (detach node)))
       fragment)))
 
-(defmacro with-parse-html-fragment ((var src) &rest body)
+(defmacro with-parse-html-fragment ((var src) &body body)
   `(with-object (,var (parse-html-fragment ,src))
      ,@body))
 

--- a/tree/document.lisp
+++ b/tree/document.lisp
@@ -195,7 +195,7 @@
 ;; with-fake-document
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defmacro with-fake-document ((var root) &rest body)
+(defmacro with-fake-document ((var root) &body body)
   `(let ((,var (make-instance 'document
                               :pointer (%xmlNewDoc (null-pointer)))))
      (unwind-protect

--- a/tree/parse.lisp
+++ b/tree/parse.lisp
@@ -166,7 +166,7 @@
 ;; with-parse-document
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defmacro with-parse-document ((var src &rest options) &rest body)
+(defmacro with-parse-document ((var src &rest options) &body body)
   `(let ((,var (parse ,src ,@options)))
      (unwind-protect
           (progn ,@body)

--- a/tree/xtree.lisp
+++ b/tree/xtree.lisp
@@ -116,13 +116,13 @@
 ;; with-libxml2-object
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defmacro with-libxml2-object ((var value) &rest body)
+(defmacro with-libxml2-object ((var value) &body body)
   `(let ((,var ,value))
      (unwind-protect 
           (progn ,@body)
        (if ,var (release ,var)))))
 
-(defmacro with-object ((var value) &rest body)
+(defmacro with-object ((var value) &body body)
   `(with-libxml2-object (,var ,value) ,@body))
 
 

--- a/xpath/expression.lisp
+++ b/xpath/expression.lisp
@@ -35,7 +35,7 @@
 
 ;;; with-compiled-expression
 
-(defmacro with-compiled-expression ((var expr) &rest body)
+(defmacro with-compiled-expression ((var expr) &body body)
   `(with-libxml2-object (,var (compile-expression ,expr)) ,@body))
      
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/xpath/xpath-context.lisp
+++ b/xpath/xpath-context.lisp
@@ -123,7 +123,7 @@
 
 (defvar *private-xpath-context*)
 
-(defmacro with-%context ((var doc node ns-map) &rest body)
+(defmacro with-%context ((var doc node ns-map) &body body)
   `(gp:with-garbage-pool (xpath-context-pool)
      (let ((,var (if (boundp '*private-xpath-context*) *private-xpath-context*
                      (gp:cleanup-register (%xmlXPathNewContext (pointer ,doc))

--- a/xpath/xpath-object.lisp
+++ b/xpath/xpath-object.lisp
@@ -70,7 +70,7 @@
 ;;; with-xpath-object
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defmacro with-xpath-object ((res (obj expr &optional (ns-map '*default-ns-map*))) &rest body)
+(defmacro with-xpath-object ((res (obj expr &optional (ns-map '*default-ns-map*))) &body body)
   `(let ((,res (eval-expression ,obj ,expr :ns-map ,ns-map)))
      (unwind-protect
           (progn ,@body)

--- a/xslt/stylesheet.lisp
+++ b/xslt/stylesheet.lisp
@@ -92,7 +92,7 @@
 ;;; with-stylesheet
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defmacro with-stylesheet ((style obj) &rest body)
+(defmacro with-stylesheet ((style obj) &body body)
   `(let ((,style (parse-stylesheet ,obj)))
      (unwind-protect
           (progn ,@body)
@@ -172,7 +172,7 @@
 ;;; with-tranform-result
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defmacro with-transform-result ((res (style doc)) &rest body)
+(defmacro with-transform-result ((res (style doc)) &body body)
   `(let ((,res (transform ,style ,doc)))
      (unwind-protect
           (progn ,@body)


### PR DESCRIPTION
This change aids slime-indentation in proper indentation of code using affected macros.
